### PR TITLE
Fix: globalexception 메시지가 null로 표시됨 수정

### DIFF
--- a/src/main/java/com/codeit/sb06deokhugamteam2/common/exception/exceptions/BasicException.java
+++ b/src/main/java/com/codeit/sb06deokhugamteam2/common/exception/exceptions/BasicException.java
@@ -3,14 +3,19 @@ package com.codeit.sb06deokhugamteam2.common.exception.exceptions;
 
 import com.codeit.sb06deokhugamteam2.common.exception.ErrorCode;
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-@AllArgsConstructor
 public class BasicException extends RuntimeException {
   protected final ErrorCode errorCode;
   protected final Map<String, Object> details;
   protected final HttpStatus httpStatus;
+
+    public BasicException(ErrorCode errorCode, Map<String, Object> details, HttpStatus httpStatus) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.details = details;
+        this.httpStatus = httpStatus;
+    }
 }


### PR DESCRIPTION
## 🎯 작업 설명
- BasicException에서 super(ErrorCode.getMessage())로 RuntimeException에 메시지 전달을 안하는중
- globalException 메시지가 null로 표시

- 정상적으로 에러코드의 메시지가 뜨도록 수정

---

## 🔗 관련 이슈
- closes #137 
