### PR TITLE
fix: 테이블 분리에 따른 도서 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/codeit/sb06deokhugamteam2/book/entity/BookStats.java
+++ b/src/main/java/com/codeit/sb06deokhugamteam2/book/entity/BookStats.java
@@ -2,11 +2,13 @@ package com.codeit.sb06deokhugamteam2.book.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 import java.util.UUID;
 
 @Entity
-@Table(name = "BookStats")
+@Table(name = "book_stats")
 @Builder
 @Getter
 @AllArgsConstructor
@@ -19,6 +21,7 @@ public class BookStats {
     @MapsId
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "book_id")
+    @NotFound(action = NotFoundAction.IGNORE)
     private Book book;
 
     @Setter

--- a/src/main/java/com/codeit/sb06deokhugamteam2/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/codeit/sb06deokhugamteam2/book/repository/BookRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package com.codeit.sb06deokhugamteam2.book.repository;
 
 import com.codeit.sb06deokhugamteam2.book.entity.Book;
 import com.codeit.sb06deokhugamteam2.book.entity.QBook;
+import com.codeit.sb06deokhugamteam2.book.entity.QBookStats;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -20,6 +21,7 @@ import java.util.List;
 public class BookRepositoryCustomImpl implements BookRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final QBook book = QBook.book;
+    private final QBookStats bookStats = QBookStats.bookStats;
 
     @Override
     public Slice<Book> findBooks(String keyword, String orderBy, String direction, String cursor, Instant nextAfter, int limit) {
@@ -28,6 +30,7 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
                 direction.equalsIgnoreCase("ASC") ? book.createdAt.asc() : book.createdAt.desc();
 
         List<Book> books = queryFactory.selectFrom(book)
+                .innerJoin(book.bookStats, bookStats).fetchJoin()
                 .where(keywordContains(keyword),
                         getCursorCondition(cursor, orderBy, direction),
                         getNextAfterCondition(nextAfter, direction))
@@ -58,14 +61,14 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
             case "publishedDate" ->
                     direction.equalsIgnoreCase("ASC") ? book.publishedDate.asc() : book.publishedDate.desc();
             case "rating" -> {
-                NumberExpression<Double> ratingSum = book.ratingSum.castToNum(Double.class);
+                NumberExpression<Double> ratingSum = bookStats.ratingSum.castToNum(Double.class);
                 NumberExpression<Double> rating = new CaseBuilder()
-                        .when(ratingSum.loe(0.0).or(book.reviewCount.loe(0)))
+                        .when(ratingSum.loe(0.0).or(bookStats.reviewCount.loe(0)))
                         .then(0.0)
-                        .otherwise(ratingSum.divide(book.reviewCount));
+                        .otherwise(ratingSum.divide(bookStats.reviewCount));
                 yield direction.equalsIgnoreCase("ASC") ? rating.asc() : rating.desc();
             }
-            case "reviewCount" -> direction.equalsIgnoreCase("ASC") ? book.reviewCount.asc() : book.reviewCount.desc();
+            case "reviewCount" -> direction.equalsIgnoreCase("ASC") ? bookStats.reviewCount.asc() : bookStats.reviewCount.desc();
             default -> direction.equalsIgnoreCase("ASC") ? book.title.asc() : book.title.desc();
         };
     }
@@ -77,17 +80,17 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
 
         return switch (orderBy) {
             case "rating" -> {
-                NumberExpression<Double> ratingSum = book.ratingSum.castToNum(Double.class);
+                NumberExpression<Double> ratingSum = bookStats.ratingSum.castToNum(Double.class);
                 NumberExpression<Double> rating = new CaseBuilder()
-                        .when(ratingSum.loe(0.0).or(book.reviewCount.loe(0)))
+                        .when(ratingSum.loe(0.0).or(bookStats.reviewCount.loe(0)))
                         .then(0.0)
-                        .otherwise(ratingSum.divide(book.reviewCount));
+                        .otherwise(ratingSum.divide(bookStats.reviewCount));
                 yield direction.equalsIgnoreCase("ASC") ? rating.goe(Double.parseDouble(cursor)) : rating.loe(Double.parseDouble(cursor));
             }
             case "publishedDate" -> direction.equalsIgnoreCase("ASC") ?
                     book.publishedDate.goe(LocalDate.parse(cursor)) : book.publishedDate.loe(LocalDate.parse(cursor));
             case "reviewCount" ->
-                    direction.equalsIgnoreCase("ASC") ? book.reviewCount.goe(Integer.parseInt(cursor)) : book.reviewCount.loe(Integer.parseInt(cursor));
+                    direction.equalsIgnoreCase("ASC") ? bookStats.reviewCount.goe(Integer.parseInt(cursor)) : bookStats.reviewCount.loe(Integer.parseInt(cursor));
             default -> direction.equalsIgnoreCase("ASC") ? book.title.goe(cursor) : book.title.loe(cursor);
         };
     }

--- a/src/test/java/com/codeit/sb06deokhugamteam2/book/fixture/BookFixture.java
+++ b/src/test/java/com/codeit/sb06deokhugamteam2/book/fixture/BookFixture.java
@@ -1,6 +1,7 @@
 package com.codeit.sb06deokhugamteam2.book.fixture;
 
 import com.codeit.sb06deokhugamteam2.book.entity.Book;
+import com.codeit.sb06deokhugamteam2.book.entity.BookStats;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -8,7 +9,7 @@ import java.util.stream.IntStream;
 
 public class BookFixture {
     public static Book createBook(int count) {
-        return Book.builder()
+        Book book = Book.builder()
                 .thumbnailUrl("thumbnail" + count + "url")
                 .title("title" + count)
                 .description("description" + count)
@@ -17,11 +18,20 @@ public class BookFixture {
                 .publishedDate(LocalDate.now())
                 .author("author" + count)
                 .build();
+        BookStats bookStats = createBookStats(book);
+        book.setBookStats(bookStats);
+        return book;
     }
 
     public static List<Book> createBooks(int number) {
         return IntStream.rangeClosed(1, number)
                 .mapToObj(BookFixture::createBook)
                 .toList();
+    }
+
+    private static BookStats createBookStats(Book book) {
+        BookStats bookStats = new BookStats();
+        bookStats.setBook(book);
+        return bookStats;
     }
 }


### PR DESCRIPTION
## 🎯 작업 설명
- 테이블 분리에 따른 도서 목록 조회 로직 수정
- 도서 테스트 유틸리티 클래스의 도서 생성 로직 변경

---

## 🔗 관련 이슈
- related to #19 
