### PR TITLE
 Fix : 프론트연동시 닉네임수정 않되는 부분 해결

### DIFF
--- a/src/main/java/com/codeit/sb06deokhugamteam2/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/codeit/sb06deokhugamteam2/user/dto/UserUpdateRequest.java
@@ -1,12 +1,19 @@
 package com.codeit.sb06deokhugamteam2.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
 
+@Getter
+public class UserUpdateRequest {
 
-public record UserUpdateRequest(
         @NotBlank(message = "닉네임은 필수 입력값입니다.")
         @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해야 합니다.")
-        String nickname
-) {
+        private final String nickname;
+
+    @JsonCreator
+    public UserUpdateRequest(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/codeit/sb06deokhugamteam2/user/repository/UserQueryRepository.java
+++ b/src/main/java/com/codeit/sb06deokhugamteam2/user/repository/UserQueryRepository.java
@@ -4,6 +4,7 @@ package com.codeit.sb06deokhugamteam2.user.repository;
 import com.codeit.sb06deokhugamteam2.common.enums.PeriodType;
 import com.codeit.sb06deokhugamteam2.user.dto.CursorPageResponse;
 import com.codeit.sb06deokhugamteam2.user.dto.PowerUserDto;
+import com.codeit.sb06deokhugamteam2.user.entity.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -16,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.codeit.sb06deokhugamteam2.comment.entity.QComment.comment;
@@ -146,5 +148,23 @@ public class UserQueryRepository {
 
         // 해당 기간(startInstant 이후)에 작성된 리뷰만 포함하도록 조건 설정
         return review.createdAt.goe(startInstant);
+    }
+
+    //물리 삭제시 N+1 문제 방지 및 JPA Cascade 작동
+    public Optional<User> findByEmailWithDeleted(String email) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(user)
+                .where(user.email.eq(email))
+                .fetchOne());
+    }
+
+    //통합 테스트용
+    public Optional<User> findByIdWithReviewsAndComments(UUID userId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(user)
+                .leftJoin(user.reviews, review).fetchJoin()
+                .leftJoin(user.comments, comment).fetchJoin()
+                .where(user.id.eq(userId))
+                .fetchOne());
     }
 }


### PR DESCRIPTION

## 🎯 작업 설명
프론트 사이트 연동해서, 닉네임 수정시 json객체 형식이 아닌 단순문자열 로 요청이 들어오는 문제
- 서비스 와 콘트롤러 코드수정(요청 본문을 수동으로 읽어 들이는 방식 사용)
- Swagger 명세(DTO 사용)를 유지하기 위해 @RequestBody 대신 HttpServletRequest를 사용
